### PR TITLE
Add setup files and simple tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Madani Maktab
+
+This project contains a small Flask server and a static web client used for student attendance management.
+
+## Requirements
+
+- Python 3.11+
+- Node.js 20 (for optional TypeScript utilities)
+- PostgreSQL database (URL provided via `DATABASE_URL`)
+
+Install Python dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Install Node dependencies (optional, for `server/db.ts`):
+
+```bash
+npm install
+```
+
+## Running
+
+Start the Flask server on port 5000:
+
+```bash
+python database_server.py
+```
+
+The frontend is served from the same directory, so open `http://localhost:5000` in your browser.
+
+## Testing
+
+A small test suite is provided using `pytest`.
+Run it with:
+
+```bash
+pytest
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "maktob-server",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsc server/db.ts --outDir dist --esModuleInterop"
+  },
+  "dependencies": {
+    "@neondatabase/serverless": "^0.9.0",
+    "drizzle-orm": "^0.30.0",
+    "ws": "^8.15.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,3 @@
-
 Flask==2.3.3
 Flask-CORS==4.0.0
-flask
-psycopg2-binary
-flask
-flask-cors
 psycopg2-binary

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,18 @@
+import pytest
+import os, sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from database_server import app
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+def test_health_endpoint(client):
+    resp = client.get('/api/health')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data.get('status') == 'healthy'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true
+  },
+  "include": ["server/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add `.gitignore` to ignore build artifacts
- document setup and usage in `README.md`
- add Node configuration with `package.json` and `tsconfig.json`
- clean `requirements.txt`
- add a basic health endpoint test

## Testing
- `python3 -m py_compile database_server.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685f40c718508321bf70427c7aaae33b