### PR TITLE
Add field name validation tests

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -228,8 +228,10 @@ class Database:
 
     # Helper for field name validation
     def _validate_field_name(self, name):
-        if not name or not re.match(r"^[a-z_][a-z0-9_]*$", name):
-            raise ValueError("Field name must be lowercase alphanumeric or underscores, start with a letter or underscore, and contain no spaces or special characters.")
+        if not name or not re.match(r"^[a-z_][a-zA-Z0-9_]*$", name):
+            raise ValueError(
+                "Field name must start with a letter or underscore and contain only alphanumeric characters or underscores."
+            )
         return True
 
     def add_field(self, name, label, type, visible=True, required=False, options=None):

--- a/backend/tests/test_field_name_validation.py
+++ b/backend/tests/test_field_name_validation.py
@@ -1,0 +1,19 @@
+import pytest
+import os, sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from db import Database
+
+@pytest.fixture
+def db_instance():
+    return Database(db_path=':memory:')
+
+@pytest.mark.parametrize('name', ['camelCase', 'studentName'])
+def test_validate_field_name_accepts_camel_case(db_instance, name):
+    assert db_instance._validate_field_name(name) is True
+
+@pytest.mark.parametrize('name', ['123name', 'name-with-dash', 'name with space', 'name$'])
+def test_validate_field_name_rejects_invalid(db_instance, name):
+    with pytest.raises(ValueError):
+        db_instance._validate_field_name(name)


### PR DESCRIPTION
## Summary
- expand _validate_field_name to allow camelCase
- add tests covering valid and invalid field names

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c19a783448321ab50b2fdf16402ee