### PR TITLE
Implement book progress monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A simple, beginner-friendly web application for managing student attendance in I
 - 🌐 **Bilingual Support** - English and Bengali (বাংলা)
 - 📱 **Mobile Friendly** - Works on phones, tablets, and computers
 - 💾 **Simple Storage** - Uses SQLite database (built into Python, no setup needed)
+- 📚 **Book Progress Monitoring** - Track textbook completion by class
 
 ## 🚀 Quick Start
 
@@ -69,6 +70,12 @@ madani-moktob-3/
 3. Choose class (optional filter)
 4. Mark each student Present/Absent
 5. Click "Save Attendance"
+
+### Tracking Book Progress
+1. Go to "Book Progress" section
+2. Choose class and textbook
+3. Enter completed pages
+4. Click "Submit" to record progress
 
 ### Viewing Reports
 1. Go to "Reports" section

--- a/Talim_PRD.md
+++ b/Talim_PRD.md
@@ -1,0 +1,52 @@
+# Product Requirements Document: Talim (Education) Section
+
+## 1. Introduction
+The **Talim** (Education) section is a new menu bar hub to monitor, analyze, and share academic progress and educational resources. It aims to foster a data-driven learning environment.
+
+## 2. Goals
+- Enhance management and monitoring of educational activities.
+- Provide a robust framework for tracking educational offerings.
+- Improve transparency and accountability in student progress and resource management.
+- Support data-driven decision-making to enhance the educational experience.
+
+## 3. Scope
+The initial release focuses on **Book Progress Monitoring**. Future plans include student performance analytics, curriculum management, a teacher resource hub, and assessment tracking.
+
+## 4. Key Features and Functionality
+The Talim section uses a **tab-based system**.
+
+### 4.1. Book Progress Monitoring Tab
+This tab provides a granular view of student textbook progress, serving as an interactive tool for accountability and timely feedback.
+
+#### 4.1.1. Class-Specific Book Management
+Lists assigned textbooks for each class, displaying:
+- **Total Pages**: Complete pages in the textbook.
+- **Completed Pages**: Real-time update of pages covered.
+- **Remaining Pages**: Outstanding pages yet to be completed.
+
+#### 4.1.2. Teacher-Led Information Uploads
+Teachers upload book progress regularly for accuracy and immediacy.
+- **Time-Stamped Entries**: Automatic timestamps for historical records and auditing.
+- **Regular Updates**: Required uploads (e.g., weekly, bi-weekly) to keep data current.
+
+#### 4.1.3. Comprehensive History Log
+A **History** sub-section provides an audit trail for all uploaded information, enabling:
+- **Track Progress Over Time**: Observe trends in book completion.
+- **Review Past Updates**: Access previous progress reports.
+- **Accountability and Transparency**: Record who uploaded what and when.
+
+## 5. Future Enhancements
+The Talim section is expandable, with future tabs for:
+- **Student Performance Analytics**: Grades, attendance, and assessment results.
+- **Curriculum Management**: Centralized storage of curriculum documents.
+- **Assessment Tracking**: Monitoring quizzes, exams, and projects.
+
+## 6. Technical Requirements (High-Level)
+- Integration with existing institutional systems.
+- Secure data storage and access.
+- Scalable architecture.
+- User-friendly interface.
+
+## 7. Success Metrics
+- Increased teacher adoption.
+- Improved accuracy and availability of student progress data.

--- a/backend/simple_server.py
+++ b/backend/simple_server.py
@@ -153,6 +153,48 @@ def add_holiday():
     except Exception as e:
         return jsonify({'error': str(e)}), 500
 
+# Book Progress Endpoints
+@app.route('/api/book_progress', methods=['GET'])
+def get_book_progress():
+    try:
+        class_name = request.args.get('class')
+        progress = db.get_latest_book_progress(class_name)
+        return jsonify(progress)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+
+@app.route('/api/book_progress', methods=['POST'])
+def add_book_progress():
+    try:
+        data = request.json
+        required = ['class', 'book_name', 'total_pages', 'completed_pages']
+        if not data or any(r not in data for r in required):
+            return jsonify({'error': 'class, book_name, total_pages and completed_pages are required'}), 400
+
+        db.add_book_progress(
+            data['class'],
+            data['book_name'],
+            int(data['total_pages']),
+            int(data['completed_pages'])
+        )
+        return jsonify({'success': True})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+
+@app.route('/api/book_progress/history')
+def book_progress_history():
+    try:
+        class_name = request.args.get('class')
+        book_name = request.args.get('book_name')
+        if not class_name or not book_name:
+            return jsonify({'error': 'class and book_name are required'}), 400
+        history = db.get_book_progress_history(class_name, book_name)
+        return jsonify(history)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
 @app.route('/api/create_sample_data', methods=['POST'])
 def create_sample_data():
     """Create sample students data in SQLite database"""

--- a/backend/tests/test_book_progress.py
+++ b/backend/tests/test_book_progress.py
@@ -1,0 +1,49 @@
+import os, sys
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from simple_server import app, db
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_add_and_get_book_progress(client):
+    data = {
+        'class': 'Class 1',
+        'book_name': 'Math',
+        'total_pages': 100,
+        'completed_pages': 10
+    }
+    resp = client.post('/api/book_progress', json=data)
+    assert resp.status_code == 200
+    out = resp.get_json()
+    assert out.get('success') is True
+
+    resp = client.get('/api/book_progress', query_string={'class': 'Class 1'})
+    assert resp.status_code == 200
+    progress = resp.get_json()
+    assert any(p['book_name'] == 'Math' for p in progress)
+
+
+def test_book_progress_history(client):
+    data1 = {
+        'class': 'Class 2',
+        'book_name': 'Science',
+        'total_pages': 80,
+        'completed_pages': 5
+    }
+    data2 = dict(data1)
+    data2['completed_pages'] = 15
+    client.post('/api/book_progress', json=data1)
+    client.post('/api/book_progress', json=data2)
+
+    resp = client.get('/api/book_progress/history', query_string={'class': 'Class 2', 'book_name': 'Science'})
+    assert resp.status_code == 200
+    history = resp.get_json()
+    assert len(history) >= 2
+    assert history[0]['completed_pages'] == 15

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -3,7 +3,7 @@ import os, sys
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from database_server import app
+from simple_server import app
 
 @pytest.fixture
 def client():


### PR DESCRIPTION
## Summary
- create book_progress table in SQLite database
- add DB helpers to save and retrieve book progress with history
- expose new API endpoints in `simple_server`
- document feature and basic usage in README
- fix tests and add coverage for book progress endpoints

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc91e2a3483218dbfecc3a2202a4c